### PR TITLE
skip updates to self

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-upgrade-command"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "colored",
  "spinoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 name = "cargo-upgrade-command"
 readme = "README.md"
 repository = "https://github.com/Araxeus/cargo-upgrade"
-version = "0.1.1"
+version = "0.2.0"
 
 [[bin]]
 name = "cargo-upgrade"


### PR DESCRIPTION
+ skip updates to self and emit an info message if found
+ change output symbol based on exit code
+ fix `\n` before first update output
