### PR TITLE
implement a tiny scheduled self update module

### DIFF
--- a/.github/workflows/test_self_update.yml
+++ b/.github/workflows/test_self_update.yml
@@ -1,0 +1,41 @@
+name: Test self_update
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-upgrade-command@0.1.0
+        run: cargo install cargo-upgrade-command@0.1.0
+
+      - run: cargo upgrade v
+
+      - name: get cargo-upgrade-command current_version
+        run: echo "current_version=$(cargo upgrade v)" >> $GITHUB_ENV
+
+      - name: Verify current version of cargo-upgrade-command
+        if: env.current_version != 'cargo-upgrade-command v0.1.0'
+        run: "echo \"Error: Current version '${{env.current_version}}' does not match expected version 'cargo-upgrade-command v0.1.0'\" && exit 1"
+
+      - name: Upgrade cargo-upgrade-command to v0.2.0
+        run: cargo run u
+
+      - name: Wait for cargo-upgrade-command to be upgraded
+        run: sleep 90 || timeout 90
+
+      - name: get cargo-upgrade-command new_version
+        run: echo "upgraded_version=(cargo upgrade v)" >> $GITHUB_ENV
+
+      - name: Verify upgraded version of cargo-upgrade-command
+        if: env.upgraded_version != 'cargo-upgrade-command v0.2.0'
+        run: "echo \"Error: Upgraded version '${{env.upgraded_version}}' does not match expected version 'cargo-upgrade-command v0.2.0'\" && exit 1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,13 @@
-name: Test self_update
+name: Tests
 
 on: [push]
 
 jobs:
-  test:
-    runs-on: windows-latest
+  test_self_update:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
@@ -18,10 +21,9 @@ jobs:
       - name: Install cargo-upgrade-command@0.1.0
         run: cargo install cargo-upgrade-command@0.1.0
 
-      - run: cargo upgrade v
-
       - name: get cargo-upgrade-command current_version
         run: echo "current_version=$(cargo upgrade v)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Verify current version of cargo-upgrade-command
         if: env.current_version != 'cargo-upgrade-command v0.1.0'
@@ -34,7 +36,8 @@ jobs:
         run: sleep 90 || timeout 90
 
       - name: get cargo-upgrade-command new_version
-        run: echo "upgraded_version=(cargo upgrade v)" >> $GITHUB_ENV
+        run: echo "upgraded_version=$(cargo upgrade v)" >> $GITHUB_ENV
+        shell: bash
 
       - name: Verify upgraded version of cargo-upgrade-command
         if: env.upgraded_version != 'cargo-upgrade-command v0.2.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   test_self_update:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
@@ -27,13 +28,37 @@ jobs:
 
       - name: Verify current version of cargo-upgrade-command
         if: env.current_version != 'cargo-upgrade-command v0.1.0'
-        run: "echo \"Error: Current version '${{env.current_version}}' does not match expected version 'cargo-upgrade-command v0.1.0'\" && exit 1"
+        run: 'echo "Error: Current version ''${{env.current_version}}'' does not match expected version ''cargo-upgrade-command v0.1.0''" && exit 1'
+
+      - name: Install `at` on ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install at
+
+      - name: Install `atrun` on macos
+        # https://apple.stackexchange.com/questions/343110/terminal-how-to-use-at
+        if: matrix.os == 'macos-latest'
+        run: sudo launchctl load -w /System/Library/LaunchDaemons/com.apple.atrun.plist
+
+      - name: On unix, print `at --version` to verify `at` is installed
+        if: matrix.os != 'windows-latest'
+        continue-on-error: true
+        run: man at && at --version
 
       - name: Upgrade cargo-upgrade-command to v0.2.0
         run: cargo run u
 
+      - name: Find the task on windows
+        if: matrix.os == 'windows-latest'
+        continue-on-error: true
+        run: schtasks /Query /tn "Upgrade cargo-update"
+
       - name: Wait for cargo-upgrade-command to be upgraded
         run: sleep 90 || timeout 90
+
+      - name: Find the task on windows
+        if: matrix.os == 'windows-latest'
+        continue-on-error: true
+        run: schtasks /Query /tn "Upgrade cargo-update"
 
       - name: get cargo-upgrade-command new_version
         run: echo "upgraded_version=$(cargo upgrade v)" >> $GITHUB_ENV
@@ -41,4 +66,4 @@ jobs:
 
       - name: Verify upgraded version of cargo-upgrade-command
         if: env.upgraded_version != 'cargo-upgrade-command v0.2.0'
-        run: "echo \"Error: Upgraded version '${{env.upgraded_version}}' does not match expected version 'cargo-upgrade-command v0.2.0'\" && exit 1"
+        run: 'echo "Error: Upgraded version ''${{env.upgraded_version}}'' does not match expected version ''cargo-upgrade-command v0.2.0''" && exit 1'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ version = "0.2.0"
 dependencies = [
  "colored",
  "spinoff",
+ "tiny-native-scheduler",
 ]
 
 [[package]]
@@ -42,6 +43,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,6 +59,15 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "once_cell"
@@ -66,6 +82,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
+name = "serde"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+
+[[package]]
 name = "spinoff"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,6 +96,44 @@ dependencies = [
  "colored",
  "once_cell",
  "paste",
+]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
+name = "tiny-native-scheduler"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1557a901229ceef5f51c0648d4d61e5edf38279d39cec0e2810f40268b07596a"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ path = "src/main.rs"
 [dependencies]
 colored = "2.0.0"
 spinoff = "0.7.0"
+tiny-native-scheduler = "0.1.1"


### PR DESCRIPTION
This uses https://github.com/Araxeus/tiny-native-scheduler / https://crates.io/crates/tiny-native-scheduler 

If cargo-upgrade-command is outdated, automatically schedule `cargo install cargo-upgrade-command` to run 1min after the process exit