### PR TITLE
allow self update

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,51 @@
+name: Test self-update
+
+on: workflow_dispatch
+
+jobs:
+  test_self_update:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-version-util
+        run: cargo install cargo-version-util
+
+      - name: Install cargo-upgrade-command
+        run: cargo install cargo-upgrade-command
+
+      - name: save cargo-upgrade-command version
+        run: echo "current_version=$(cargo upgrade v)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Change version to v0.1.0
+        run: cargo version-util set-version 0.1.0
+
+      - name: install cargo-upgrade-command@0.1.0
+        run: cargo install --path .
+
+      - name: get cargo-upgrade-command version after install
+        run: echo "installed_version=$(cargo upgrade v)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Verify installed version of cargo-upgrade-command
+        if: env.installed_version != 'cargo-upgrade-command v0.1.0'
+        run: 'echo "Error: installed version ''${{env.installed_version}}'' does not match expected version ''cargo-upgrade-command v0.1.0''" && exit 1'
+
+      - name: Upgrade cargo-upgrade-command
+        run: cargo upgrade
+
+      - name: get cargo-upgrade-command new_version
+        run: echo "upgraded_version=$(cargo upgrade v)" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Verify upgraded version of cargo-upgrade-command
+        if: env.upgraded_version != env.current_version
+        run: 'echo "Error: Upgraded version ''${{env.upgraded_version}}'' does not match expected current version ''${{env.current_version}}''" && exit 1'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::fs::{create_dir, rename};
+use std::fs::{create_dir, remove_dir_all, rename};
 use std::io::{BufRead, BufReader, Result};
 
 use std::process::{Command, Stdio};
@@ -217,9 +217,11 @@ fn move_executable_to_temp_folder() -> Result<()> {
 
     // Generate a unique file name for the executable in the temp directory
     let cloned_exe_dir = temp_dir.join(env!("CARGO_PKG_NAME"));
-    if !cloned_exe_dir.exists() {
-        create_dir(&cloned_exe_dir)?;
+    if cloned_exe_dir.exists() {
+        remove_dir_all(&cloned_exe_dir)?;
     }
+
+    create_dir(&cloned_exe_dir)?;
 
     let mut cloned_exe_path = cloned_exe_dir.join(current_exe.file_name().unwrap());
     let mut i = 0;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::env;
+use std::fs::rename;
 use std::io::{BufRead, BufReader, Result};
 
 use std::process::{Command, Stdio};
@@ -190,13 +192,7 @@ pub fn update_all_packages() -> Result<()> {
             println!();
         }
         if package.name == env!("CARGO_PKG_NAME") {
-            println!(
-                "{name} is outdated [{old_v} -> {new_v}] but it cannot update itself.\nRun `cargo install {name}` to update it",
-                name = formatted.name,
-                old_v = formatted.version,
-                new_v = formatted.new_version.unwrap()
-            );
-            continue;
+            move_executable_to_temp_folder()?;
         }
         println!(
             "Upgrading {} from {} to {}",
@@ -207,6 +203,31 @@ pub fn update_all_packages() -> Result<()> {
         update_package(&package.name)?;
         done_one = true;
     }
+
+    Ok(())
+}
+
+fn move_executable_to_temp_folder() -> Result<()> {
+    let current_exe = env::current_exe()?;
+    let temp_dir = env::temp_dir();
+
+    // Generate a unique file name for the executable in the temp directory
+    let mut cloned_exe_path = temp_dir.join(current_exe.file_name().unwrap());
+    let mut i = 0;
+    while cloned_exe_path.exists() {
+        i += 1;
+
+        cloned_exe_path = temp_dir.join(format!(
+            "{}-{i}",
+            current_exe.file_stem().unwrap().to_str().unwrap()
+        ));
+        if cfg!(windows) {
+            cloned_exe_path.set_extension("exe");
+        }
+    }
+
+    // Move the current executable to the temp directory
+    rename(&current_exe, &cloned_exe_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
By moving the current executable to a temp dir, we allow cargo to install a new version in it's place